### PR TITLE
Add the OBS link to install Adapta in openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,12 @@ Installation from Package(s)
 
  * PPA: https://launchpad.net/~tista/+archive/ubuntu/adapta
 
+ * OBS (openSUSE Tumbleweed): https://build.opensuse.org/package/show/home:Ronis_BR/adapta-gtk-theme
+
  > **Note:**
  >
  >   * Solus OS has an eopkg (ypkg) in main repository.
+ >
 
 Installation from Git Source
 ----------------------------


### PR DESCRIPTION
I am packing the Adapta theme suit to openSUSE. This commit add to the README.md the link to my devel repository in OBS in which the user can install Adapta.

The theme is in the process of being accepted in the main distro (openSUSE Tumbleweed). Hence, after that (which should take a while), I will update the README.md again.