### PR TITLE
Color default workspace name text so that it is reable (light theme)

### DIFF
--- a/shell/sass/cinnamon/_common.scss
+++ b/shell/sass/cinnamon/_common.scss
@@ -2005,6 +2005,7 @@ $icon_size: 16px;
 .expo-workspaces-name-entry#selected {
   @include fontscaling($ref_size * 0.9);
   @include entry(osd);
+  color: $osd_fg_color;
   -cinnamon-caption-spacing: 12px;
   height: 15px;
   padding: 4px 8px;


### PR DESCRIPTION
The font color in the light theme was dark against a dark background, so it was hard to read. 

![expo font color](https://cloud.githubusercontent.com/assets/12450263/21077430/1d9bc3fc-bf43-11e6-87b3-9ef0d37e341a.png)


I looked through the scss and saw that the color wasn't set in .expo-workspaces-name-entry, so I set it to osd_fg_color. It's readable now. 

![new expo font color](https://cloud.githubusercontent.com/assets/12450263/21077435/466cedd8-bf43-11e6-902d-8d2420193a33.png)
