### PR TITLE
Fix typo.

### DIFF
--- a/shell/sass/gnome-shell/_common.scss
+++ b/shell/sass/gnome-shell/_common.scss
@@ -1900,11 +1900,11 @@ StScrollBar {
                             (left, 0 2px 2px 0),
                             (right, 2px 0 0 2px) {
     &.#{$_dock} #dash {
-      border-dadius: #{$_radius};
+      border-radius: #{$_radius};
       background-color: rgba(19, 25, 28, 1.0);
     }
     &.#{$_dock}:overview #dash {
-      border-dadius: #{$_radius};
+      border-radius: #{$_radius};
       background-color: $osd_slight_fill_color;
     }
     &.#{$_dock}.extended #dash {


### PR DESCRIPTION
Fix a typo in the border-radius property.