### PR TITLE
Chrome: Fix button visibility in Nokto theme

### DIFF
--- a/extra/chrome/adapta-nokto-theme/manifest.json
+++ b/extra/chrome/adapta-nokto-theme/manifest.json
@@ -25,6 +25,7 @@
       "button_background": [0, 0, 0, 0]
     },
     "tints": {
+      "buttons": [0.8, 0.04, 0.73],
       "frame": [-1, -1, -1],
       "frame_inactive": [-1, -1, -1],
       "frame_incognito": [-1, -1, -1],


### PR DESCRIPTION
I was having the following issue with the Nokto Chrome theme where buttons were not very visible:

![nokto1](https://cloud.githubusercontent.com/assets/129148/23041799/1b5556e8-f44b-11e6-88c2-aa3e95df1296.png)

This change sets the button color tint to the closest analogue of the Nokto foreground color I could make:

![nokto2](https://cloud.githubusercontent.com/assets/129148/23041828/3500a44e-f44b-11e6-83e1-4a0393501131.png)
