### PR TITLE
Remove transitions on omnisearchrow to prevent flashing on dark variant

### DIFF
--- a/gtk/sass/3.20/_misc.scss
+++ b/gtk/sass/3.20/_misc.scss
@@ -1377,6 +1377,9 @@ frame.gb-search-frame {
   border-radius: 0;
 }
 
+//don't have transitions on omnisearchrows to prevent flashing in dark variant
+list > omnisearchrow { transition: none; }
+
 frame.gb-search-frame border { border: none; }
 
 .gb-search-entry-occurrences-tag {

--- a/gtk/sass/3.22/_misc.scss
+++ b/gtk/sass/3.22/_misc.scss
@@ -1568,6 +1568,9 @@ frame.gb-search-frame {
   border-width: 0;
 }
 
+//don't have transitions on omnisearchrows to prevent flashing in dark variant
+list > omnisearchrow { transition: none; }
+
 // Tweaks for the editortweak popover in the editor.
 editortweak {
   button { padding: 0 rem(6px) 0 rem(6px); }

--- a/gtk/sass/4.0/_misc.scss
+++ b/gtk/sass/4.0/_misc.scss
@@ -1565,6 +1565,9 @@ frame.gb-search-frame {
   border-width: 0;
 }
 
+//don't have transitions on omnisearchrows to prevent flashing in dark variant
+list > omnisearchrow { transition: none; }
+
 // Tweaks for the editortweak popover in the editor.
 editortweak {
   button { padding: 0 rem(6px) 0 rem(6px); }


### PR DESCRIPTION
In applications that use OmniBox Search widgets (like GNOME Builder), with the dark theme selected, the separators between OmniSearchRows will flash white whenever the list is update (like when the search text is changed. This behavior doesn't happen in Adwaita. 

Removing the transitions on these widgets prevents them from flashing, and since these results change instantly anyway the lack of a transition doesn't affect the visual look of the results.

Gif showing the flashing in Pop (based on Adapta, issue happened in both Adapta and Pop) versus Adwaita:

![dbf35d2c-2f2a-11e7-904c-a26a3add26aa](https://cloud.githubusercontent.com/assets/5883565/25715988/b7442308-30ba-11e7-8ab5-765913257a52.gif)
