### PR TITLE
Add panel-grid item for MATE taskbar widget

### DIFF
--- a/gtk/asset/assets-clone/panel-grid.svg
+++ b/gtk/asset/assets-clone/panel-grid.svg
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="panel-grid.svg"
+   height="22"
+   id="svg7384"
+   inkscape:version="0.92+devel unknown"
+   version="1.1"
+   width="12">
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:bbox-nodes="false"
+     inkscape:bbox-paths="true"
+     bordercolor="#666666"
+     borderopacity="1"
+     inkscape:current-layer="layer12"
+     inkscape:cx="-1.4204108"
+     inkscape:cy="15.184714"
+     gridtolerance="10"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     id="namedview88"
+     inkscape:object-nodes="false"
+     inkscape:object-paths="false"
+     objecttolerance="10"
+     pagecolor="#574f4a"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     showborder="true"
+     showgrid="false"
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-others="false"
+     inkscape:snap-to-guides="true"
+     inkscape:window-height="1376"
+     inkscape:window-maximized="1"
+     inkscape:window-width="2560"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:zoom="22.627417"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       empspacing="2"
+       enabled="true"
+       id="grid4866"
+       originx="0"
+       originy="0"
+       snapvisiblegridlinesonly="true"
+       spacingx="1"
+       spacingy="1"
+       type="xygrid"
+       visible="true" />
+    <inkscape:grid
+       color="#000000"
+       empcolor="#000000"
+       empopacity="0"
+       empspacing="4"
+       enabled="true"
+       id="grid5968"
+       opacity="0.1254902"
+       originx="119.9998"
+       originy="650"
+       snapvisiblegridlinesonly="true"
+       spacingx="0.5"
+       spacingy="0.5"
+       type="xygrid"
+       visible="true" />
+  </sodipodi:namedview>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="status"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer10"
+     inkscape:label="devices"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer11"
+     inkscape:label="apps"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer13"
+     inkscape:label="places"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer14"
+     inkscape:label="mimetypes"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer15"
+     inkscape:label="emblems"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="g71291"
+     inkscape:label="emotes"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="g4953"
+     inkscape:label="categories"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer12"
+     inkscape:label="actions"
+     style="display:inline"
+     transform="translate(-121.0004,-861)">
+    <rect
+       height="4"
+       id="rect20592"
+       rx="1"
+       ry="1"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f6f6f6;fill-opacity:0.23312288;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4.5000014"
+       x="125.0002"
+       y="864" />
+    <rect
+       height="4"
+       id="rect16730"
+       rx="1"
+       ry="1"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f6f6f6;fill-opacity:0.23312288;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4.5000014"
+       x="125.0002"
+       y="870" />
+    <rect
+       height="4"
+       id="rect16732"
+       rx="1"
+       ry="1"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f6f6f6;fill-opacity:0.23312288;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4.5000014"
+       x="125.0002"
+       y="876" />
+  </g>
+</svg>

--- a/gtk/asset/assets-gtk3-scripts/assets-clone-gtk3.txt
+++ b/gtk/asset/assets-gtk3-scripts/assets-clone-gtk3.txt
@@ -8,3 +8,4 @@ show-apps-hover-shadow
 show-apps-checked
 show-apps-checked-shadow
 show-apps-shadow
+panel-grid

--- a/gtk/sass/3.20/_3rd-party.scss
+++ b/gtk/sass/3.20/_3rd-party.scss
@@ -2496,6 +2496,14 @@ PanelToplevel.background {
   box-shadow: none;
 }
 
+MatePanelAppletFrameDBus {
+  // Grid button to move tasklist
+  background-image: -gtk-scaled(url("assets/panel-grid.svg"));
+  background-color: transparent;
+  background-repeat: no-repeat;
+  background-position: left;
+}
+
 PanelSeparator {
   border-width: 0;
   background: none;

--- a/gtk/sass/3.22/_3rd-party.scss
+++ b/gtk/sass/3.22/_3rd-party.scss
@@ -2415,6 +2415,14 @@ PanelToplevel.background {
   box-shadow: none;
 }
 
+MatePanelAppletFrameDBus {
+  // Grid button to move tasklist
+  background-image: -gtk-scaled(url("assets/panel-grid.svg"));
+  background-color: transparent;
+  background-repeat: no-repeat;
+  background-position: left;
+}
+
 PanelSeparator {
   border-width: 0;
   background: none;

--- a/gtk/sass/4.0/_3rd-party.scss
+++ b/gtk/sass/4.0/_3rd-party.scss
@@ -2296,6 +2296,14 @@ PanelToplevel.background {
   box-shadow: none;
 }
 
+MatePanelAppletFrameDBus {
+  // Grid button to move tasklist
+  background-image: -gtk-scaled(url("assets/panel-grid.svg"));
+  background-color: transparent;
+  background-repeat: no-repeat;
+  background-position: left;
+}
+
 PanelSeparator {
   border-width: 0;
   background: none;

--- a/gtk/sass/gtk-dark.gresource.xml.in
+++ b/gtk/sass/gtk-dark.gresource.xml.in
@@ -5,6 +5,7 @@
     <file preprocess='to-pixdata'>assets/bar-green.svg</file>
     <file preprocess='to-pixdata'>assets/bar-red.svg</file>
     <file preprocess='to-pixdata'>assets/bar-yellow.svg</file>
+    <file preprocess='to-pixdata'>assets/panel-grid.svg</file>
     <file preprocess='to-pixdata'>assets/calendar-day-selected@2.png</file>
     <file preprocess='to-pixdata'>assets/calendar-day-selected.png</file>
     <file preprocess='to-pixdata'>assets/checkbox-active-selectionmode-dark@2.png</file>

--- a/gtk/sass/gtk.gresource.xml.in
+++ b/gtk/sass/gtk.gresource.xml.in
@@ -5,6 +5,7 @@
     <file preprocess='to-pixdata'>assets/bar-green.svg</file>
     <file preprocess='to-pixdata'>assets/bar-red.svg</file>
     <file preprocess='to-pixdata'>assets/bar-yellow.svg</file>
+    <file preprocess='to-pixdata'>assets/panel-grid.svg</file>
     <file preprocess='to-pixdata'>assets/calendar-day-selected@2.png</file>
     <file preprocess='to-pixdata'>assets/calendar-day-selected.png</file>
     <file preprocess='to-pixdata'>assets/checkbox-active-selectionmode@2.png</file>


### PR DESCRIPTION
When Adapta is currently used in MATE, there is no widget to move the taskbar widget in the MATE panel, which makes customizing the bottom panel or manipulating these widgets very difficult without switching to a different theme. This PR adds an image asset for the separator widget that allows for dragging the taskbar around and changing its settings.