### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Installation from Package(s)
 
  * Copr: https://copr.fedorainfracloud.org/coprs/heikoada/gtk-themes/
 
- * OBS (openSUSE Tumbleweed): https://build.opensuse.org/package/show/home:Ronis_BR/adapta-gtk-theme
+ * openSUSE (Tumbleweed): package can be found in official repositories
 
  * PPA: https://launchpad.net/~tista/+archive/ubuntu/adapta
 


### PR DESCRIPTION
adapta-gtk-theme have been accepted to the official openSUSE Tumbleweed repositories as of today. Update readme to reflect this.

Ref: https://build.opensuse.org/package/show/openSUSE:Factory/adapta-gtk-theme