### PR TITLE
Fix not beeing able to resize windows in openbox because window borders missing

### DIFF
--- a/wm/openbox-3/themerc
+++ b/wm/openbox-3/themerc
@@ -156,7 +156,7 @@ menu.title.text.font:shadow=n
 
 
 # Everything else
-border.width: 0
+border.width: 1
 padding.width: 8
 padding.height: 6
 window.handle.width: 0

--- a/wm/openbox-3/themerc
+++ b/wm/openbox-3/themerc
@@ -156,7 +156,7 @@ menu.title.text.font:shadow=n
 
 
 # Everything else
-border.width: 1
+border.width: 2
 padding.width: 8
 padding.height: 6
 window.handle.width: 0

--- a/wm/openbox-3/themerc
+++ b/wm/openbox-3/themerc
@@ -28,7 +28,7 @@ window.active.title.bg.color: #222D32
 window.active.title.separator.color: #222D32
 window.active.text.justify: center
 
-window.active.title.bg.highlight: 20
+window.active.title.bg.highlight: 0
 window.active.title.bg.shadow: 0
 
 window.active.label.bg: parentrelative
@@ -69,7 +69,7 @@ window.inactive.title.bg.color: #222D32
 window.inactive.title.separator.color: #222D32
 window.inactive.text.justify: center
 
-window.inactive.title.bg.highlight: 20
+window.inactive.title.bg.highlight: 0
 window.inactive.title.bg.shadow: 0
 
 window.inactive.label.bg: parentrelative

--- a/wm/openbox-3/themerc
+++ b/wm/openbox-3/themerc
@@ -23,7 +23,7 @@ menu.separator.padding.height: 4
 
 # Active window
 window.active.border.color: #222D32
-window.active.title.bg: raised solid
+window.active.title.bg: flat solid
 window.active.title.bg.color: #222D32
 window.active.title.separator.color: #222D32
 window.active.text.justify: center
@@ -64,7 +64,7 @@ window.active.button.disabled.image.color: #555F64
 
 # Inactive window
 window.inactive.border.color: #222D32
-window.inactive.title.bg: raised solid
+window.inactive.title.bg: flat solid
 window.inactive.title.bg.color: #222D32
 window.inactive.title.separator.color: #222D32
 window.inactive.text.justify: center

--- a/wm/openbox-3/themerc-nokto
+++ b/wm/openbox-3/themerc-nokto
@@ -156,7 +156,7 @@ menu.title.text.font:shadow=n
 
 
 # Everything else
-border.width: 0
+border.width: 1
 padding.width: 8
 padding.height: 6
 window.handle.width: 0

--- a/wm/openbox-3/themerc-nokto
+++ b/wm/openbox-3/themerc-nokto
@@ -156,7 +156,7 @@ menu.title.text.font:shadow=n
 
 
 # Everything else
-border.width: 1
+border.width: 2
 padding.width: 8
 padding.height: 6
 window.handle.width: 0

--- a/wm/openbox-3/themerc-nokto
+++ b/wm/openbox-3/themerc-nokto
@@ -23,12 +23,12 @@ menu.separator.padding.height: 4
 
 # Active window
 window.active.border.color: #222D32
-window.active.title.bg: raised solid
+window.active.title.bg: flat solid
 window.active.title.bg.color: #222D32
 window.active.title.separator.color: #222D32
 window.active.text.justify: center
 
-window.active.title.bg.highlight: 20
+window.active.title.bg.highlight: 0
 window.active.title.bg.shadow: 0
 
 window.active.label.bg: parentrelative
@@ -64,12 +64,12 @@ window.active.button.disabled.image.color: #555F64
 
 # Inactive window
 window.inactive.border.color: #222D32
-window.inactive.title.bg: raised solid
+window.inactive.title.bg: flat solid
 window.inactive.title.bg.color: #222D32
 window.inactive.title.separator.color: #222D32
 window.inactive.text.justify: center
 
-window.inactive.title.bg.highlight: 20
+window.inactive.title.bg.highlight: 0
 window.inactive.title.bg.shadow: 0
 
 window.inactive.label.bg: parentrelative


### PR DESCRIPTION
I'm the maintainer of the Manjaro LXDE community edition and I'm thinking of using the adapta theme in the next release. However, I noticed that window borders are missing and windows cannot be resized without the alt modifier (the only applications which can be resized only with mouse are the ones that have the Gnome style borders).

So this PR fixes that.