### PR TITLE
Set color for virtual keyboard so that keys are visible in Adapta(-Eta)

### DIFF
--- a/shell/sass/cinnamon/_common.scss
+++ b/shell/sass/cinnamon/_common.scss
@@ -1159,6 +1159,7 @@ $icon_size: 16px;
 #keyboard {
   border-width: 0;
   background-color: shellopacity($osd_bg_color, 0.7);
+  color: $osd_fg_color;
 
   &-layout {
     spacing: 10px;


### PR DESCRIPTION
Running Cinnamon 3.4 in Arch Linux. Keyboard keys are not visible in non-dark theme.

Before change:
![keyboard-before](https://user-images.githubusercontent.com/6200846/31048767-a1678a90-a5f2-11e7-994c-1dc55a836b88.png)

After:
![keyboard-after](https://user-images.githubusercontent.com/6200846/31048769-a5dc9f98-a5f2-11e7-84a7-097b1ea5e41c.png)
