### PR TITLE
configure.ac: fixup pkg-config detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,10 +36,7 @@ ADAPTA_OPTION([CHROME_LEGACY],[chrome_legacy],[Chrome(ium)-legacy],[disable])
 ADAPTA_OPTION([PLANK],        [plank],        [Plank],             [disable])
 ADAPTA_OPTION([TELEGRAM],     [telegram],     [Telegram],          [disable])
 
-AC_PATH_PROG([PKG_CONFIG], [pkg-config])
-if test x"$PKG_CONFIG" = x; then
-	AC_MSG_ERROR(['pkg-config' not found.])
-fi
+PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES(GDK_PIXBUF, [gdk-pixbuf-2.0 >= 2.32.2])
 PKG_CHECK_MODULES(GLIB,       [glib-2.0 >= 2.48.0])


### PR DESCRIPTION
The old approach didn't honor the $PKG_CONFIG
variable if it was set already. PKG_PROG_PKG_CONFIG
honors it, which is useful if one wants to use another
pkg-config binary than /usr/bin/pkg-config. Many distros
also ban the direct use of it.