### PR TITLE
Cinnamon 4 update - GWL, Overview and alternative stock menu + bugfixes

### DIFF
--- a/shell/sass/cinnamon/_common.scss
+++ b/shell/sass/cinnamon/_common.scss
@@ -1836,7 +1836,11 @@ padding: 0.5em;
   background-color: $hidden_fill_color;
   transition-duration: 0.2s;
 
-  // .vertical & { padding: 3px; } // NEEDS_REVIEW
+.vertical & {
+  width: 10px;
+  height: 20px;
+  // padding: 3px 0; // NEEDS_REVIEW
+}
 
   &:hover {
     color: $selected_fg_color;
@@ -1869,7 +1873,11 @@ padding: 0.5em;
 .workspace-graph {
   padding: 3px;
   spacing: 3px;
-
+  
+  .vertical & {
+    padding: 0; 
+  }
+  
   .workspace {
     border: 1px solid shellopacity(black, 0.4);
     background-gradient-direction: none;

--- a/shell/sass/cinnamon/_common.scss
+++ b/shell/sass/cinnamon/_common.scss
@@ -1579,6 +1579,160 @@ $ws_thumb_spacing: 32px;
     background: none;
   }
 }
+// GWL is a cinnamon v>4.0 stock applet
+// /*******************************
+//  * Grouped window list
+//  *******************************/
+
+.grouped-window-list {
+  &-thumbnail-label {
+    padding-left: 4px;
+  }
+  &-number-label {
+    @include fontscaling($ref_size * 0.9);
+    color: $selected_fg_color;
+    font-weight: 700;
+  }
+  &-badge {
+    border-radius: 256px;
+    background-color: #000000;
+    // to prevent overlap of badge and box-shadow in top and left panel in larger icon sizes.
+    .panel-top & { margin-top: 2px }
+    .panel-left & { margin-left: 2px }
+  }
+  &-button-label {
+    padding-left: 4px;
+  }
+  &-thumbnail-alert {
+    background: rgba(255, 52, 52, 0.3);
+  }
+
+  &-item-box {
+    border: 0 none transparent;
+    border-image: none;
+    background-image: none;
+    background-color: $hidden_fill_color;
+    color: $osd_fg_color;
+    box-shadow: $empty_shadow;
+    font-weight: 400;
+    .panel-top &,
+    .panel-bottom &,
+    .panel-left &,
+    .panel-right & {
+      StIcon, StBin { padding: 0; }
+    }
+
+    @each $position, $_indicator in (top, 0 2px),
+                                    (bottom, 0 -2px),
+                                    (left, 2px 0),
+                                    (right, -2px 0) {
+      .panel-#{$position} & {
+        spacing: 0;
+        padding: 0;
+        border: 0 none transparent;
+        border-image: none;
+        background-color: $hidden_fill_color;
+        box-shadow: $empty_shadow;
+        // emulate two state themeing as per current themeing for icing task manager and window-list.
+        &:active, &:hover, &active:hover {
+          background-color: $hidden_fill_color;
+          box-shadow: inset #{$_indicator} $osd_outline_fill_color;
+        }
+        &:focus, &:active:focus, &:focus:hover, &:active:focus:hover {
+          background-color: $hidden_fill_color;
+          box-shadow: inset #{$_indicator} $osd_indicator_color;
+        }
+      }
+    }
+
+    StLabel {
+      font-weight: 400;
+
+      .panel-top &,
+      .panel-bottom & {
+        &:ltr {
+          padding: 0 (6px - 2px) 0 0;
+        }
+        &:rtl {
+          padding: 0 0 0 (6px - 2px);
+        }
+      }
+    }
+
+    &:progress,
+    .progress {
+      background-gradient-start: $accent_fill_color;
+      background-gradient-end: $accent_fill_color;
+    }
+  }
+
+  &-item-demands-attention {
+    background-gradient-start: $accent_fill_color;
+    background-gradient-end: $accent_fill_color;
+    color: $selected_fg_color;
+
+    @each $position, $_indicator in (top, 0 2px), (bottom, 0 -2px), (left, 2px 0), (right, -2px 0) {
+      .panel-#{$position} & {
+        box-shadow: inset #{$_indicator} $accent_color;
+      }
+    }
+  }
+  &-thumbnail-menu {
+    padding: 20px;
+    border: none;
+    border-image: url('assets/misc/osd.svg') 9 9 9 9;
+    border-radius: 2px;
+    color: $osd_fg_color;
+    background: none;
+
+    > StBoxLayout {
+      padding: 4px;
+    }
+
+    .item-box {
+      padding: 8px;
+      border-radius: 0; // fill entire surface to cover up the parent
+      background-color: $osd_bg_color; // use opaque
+      &:outlined,
+      &:selected { border-radius: 2px; }
+      &:outlined {
+        padding: 6px;
+        border: 2px solid $osd_outline_fill_color;
+      }
+      &:selected {
+        background-color: mix($osd_bg_color, $accent_color, 75%);
+        color: $inverted_accent_label_color;
+      }
+
+      > StBoxLayout { // icon and title
+        &:ltr { margin: 6px 0 0 6px; }
+        &:rtl { margin: 6px 6px 0 0; }
+
+        StLabel { padding-bottom: 0.1em; }
+      }
+
+      > StButton { // close button
+        &:ltr { margin: 6px 6px 0 0; }
+        &:rtl { margin: 6px 0 0 6px; }
+      }
+    }
+
+    .thumbnail {
+      width: 256px;
+      margin: 6px;
+    }
+
+    .thumbnail-box {
+      padding: 2px;
+      spacing: 4px;
+    }
+
+    .separator {
+      width: 1px;
+      background: $borders_color;
+    }
+  }
+}
 
 
 // /***********************************

--- a/shell/sass/cinnamon/_common.scss
+++ b/shell/sass/cinnamon/_common.scss
@@ -1260,7 +1260,17 @@ $ws_thumb_spacing: 32px;
   // from other applet menus
   &-background {
   }
-
+  // top-box and systembuttons-box are for the abortive version 4.0 stock menu. Included in case it ever returns.
+  &-top-box {
+    spacing: 10px;
+  }
+  &-systembuttons-box {
+     padding: 5px 0;
+     }
+    .menu-favorites-button {
+    padding: 5px;
+    &:hover { @include button(flat-hover); }
+  }
   &-favorites-box {
     padding: 7px;
     border-radius: 0;

--- a/shell/sass/cinnamon/_common.scss
+++ b/shell/sass/cinnamon/_common.scss
@@ -1412,7 +1412,7 @@ $ws_thumb_spacing: 32px;
 
 #menu-search-entry {
   @extend %entry;
-  width: 24em;
+  width: 16em;
   caret-color: $fg_color;
   font-weight: 500;
 }
@@ -1424,6 +1424,7 @@ $ws_thumb_spacing: 32px;
 
 // Context menu (at the moment only for favorites)
 .menu-context-menu {
+padding: 0.5em;
 }
 
 

--- a/shell/sass/cinnamon/_common.scss
+++ b/shell/sass/cinnamon/_common.scss
@@ -606,6 +606,15 @@ $icon_size: 16px;
 
 #overview { spacing: 12px; }
 
+// >=4.0
+.overview-empty-placeholder {
+    color: $osd_fg_color;
+    font-size: 1.5em;
+}
+.window-border {
+    outline: 0 none transparent;
+    border: 2px solid $osd_indicator_color;
+}
 .window-caption {
   -cinnamon-caption-spacing: 12px;
   spacing: 25px;
@@ -617,7 +626,8 @@ $icon_size: 16px;
 
   // FIXME: Cinnamon does not have 'window-clone-border'
   // and the name 'selected' looks incorrect, should be 'focused' instead
-  &#selected {
+  // selector is :focus for >=4.0
+  &#selected, &:focus {
     spacing: 25px;
     color: $selected_fg_color;
     background-color: $osd_indicator_color;


### PR DESCRIPTION
Includes an updated version of GWL PR #744 - theming for pseudo-classes matches existing theming for Icing Task Manager.

Also adds some style-classes for the alternative stock menu in Cinnamon 4.0 - at time of writing this menu is not being distributed with Cinnamon 4.0.1 but it might come back.

Updates the overview section with new style-class for Cinnamon 4.

Bug fix to the workspace-switcher applet in vertical panels.

For Cinnamenu compatibility reduced menu search entry width and added some padding to menu-context-menu.
