### PR TITLE
Add 10px drag corner to the bottom corners for xfwm4.

### DIFF
--- a/wm/asset/assets-xfwm/bottom-left-active.svg
+++ b/wm/asset/assets-xfwm/bottom-left-active.svg
@@ -9,9 +9,9 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   height="2"
-   width="2"
-   viewBox="0 0 2 2"
+   height="10"
+   width="10"
+   viewBox="0 0 10 10"
    id="svg3216"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -72,7 +72,14 @@
      style="fill:#222d32;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect3272"
      width="2"
-     height="2"
+     height="10"
      x="0"
      y="0" />
+  <rect
+     style="fill:#222d32;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect3272-3"
+     width="10"
+     height="2"
+     x="0"
+     y="8" />
 </svg>

--- a/wm/asset/assets-xfwm/bottom-left-inactive.svg
+++ b/wm/asset/assets-xfwm/bottom-left-inactive.svg
@@ -9,9 +9,9 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   height="2"
-   width="2"
-   viewBox="0 0 2 2"
+   height="10"
+   width="10"
+   viewBox="0 0 10 10"
    id="svg3216"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -72,7 +72,14 @@
      style="fill:#222d32;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect3272"
      width="2"
-     height="2"
+     height="10"
      x="0"
      y="0" />
+  <rect
+     style="fill:#222d32;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect3272-3"
+     width="10"
+     height="2"
+     x="0"
+     y="8" />
 </svg>

--- a/wm/asset/assets-xfwm/bottom-right-active.svg
+++ b/wm/asset/assets-xfwm/bottom-right-active.svg
@@ -9,9 +9,9 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   height="2"
-   width="2"
-   viewBox="0 0 2 2"
+   height="10"
+   width="10"
+   viewBox="0 0 10 10"
    id="svg3216"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -72,7 +72,14 @@
      style="fill:#222d32;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect3272"
      width="2"
+     height="10"
+     x="8"
+     y="0" />
+  <rect
+     style="fill:#222d32;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect3272-3"
+     width="10"
      height="2"
      x="0"
-     y="0" />
+     y="8" />
 </svg>

--- a/wm/asset/assets-xfwm/bottom-right-inactive.svg
+++ b/wm/asset/assets-xfwm/bottom-right-inactive.svg
@@ -9,9 +9,9 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   height="2"
-   width="2"
-   viewBox="0 0 2 2"
+   height="10"
+   width="10"
+   viewBox="0 0 10 10"
    id="svg3216"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -72,7 +72,14 @@
      style="fill:#222d32;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect3272"
      width="2"
+     height="10"
+     x="8"
+     y="0" />
+  <rect
+     style="fill:#222d32;fill-opacity:1;stroke:none;stroke-width:6;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect3272-3"
+     width="10"
      height="2"
      x="0"
-     y="0" />
+     y="8" />
 </svg>


### PR DESCRIPTION
By default it is very hard to drag the default 2px corner for resizing the window.
With this commit, we use 10 px drag corner, to easily resize windows under xfwm4.